### PR TITLE
Spine index로 구조 변경 (spine id 사용 안함)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@
   2. 왼쪽 또는 오른쪽 클릭으로 인한 변경
   3. 하단 슬라이더를 이용한 변경
 - 따라서 다음과 같은 변경이 있을 시에 store 내에 **viewerPageCount** 를 변경시킨다.
-- **viewerPageCount** 변경됨에 따라서 **pagesOffset**, **pageOffset** 를 변경시켜주어 그에 맞는 page 를 찾아서 viewer 와 슬라이더 카운트를 맞게 변경해준다.
+- **viewerPageCount** 변경됨에 따라서 **viewerSpineIndex**, **viewrSpinePostion** 를 변경시켜주어 그에 맞는 page 를 찾아서 viewer 와 슬라이더 카운트를 맞게 변경해준다.
 
-> 그림에서 각각 **pagesOffset** 는 **Spine Index** 로, **pageOffset** 는 **column count** 로 표현하였다.
+> 그림에서 각각 **viewerSpineIndex** 는 **Spine Index** 로, **viewrSpinePostion** 는 **column count** 로 표현하였다.
 
 ![](https://hyuntaeeom-personal.s3.ap-northeast-2.amazonaws.com/RIDI+mini-vewer/viewer-store-change-diagram.png)
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@
   2. 왼쪽 또는 오른쪽 클릭으로 인한 변경
   3. 하단 슬라이더를 이용한 변경
 - 따라서 다음과 같은 변경이 있을 시에 store 내에 **viewerPageCount** 를 변경시킨다.
-- **viewerPageCount** 변경됨에 따라서 **viewerSpineIndex**, **viewrSpinePostion** 를 변경시켜주어 그에 맞는 page 를 찾아서 viewer 와 슬라이더 카운트를 맞게 변경해준다.
+- **viewerPageCount** 변경됨에 따라서 **viewerSpineIndex**, **viewerSpinePosition** 를 변경시켜주어 그에 맞는 page 를 찾아서 viewer 와 슬라이더 카운트를 맞게 변경해준다.
 
-> 그림에서 각각 **viewerSpineIndex** 는 **Spine Index** 로, **viewrSpinePostion** 는 **column count** 로 표현하였다.
+> 그림에서 각각 **viewerSpineIndex** 는 **Spine Index** 로, **viewerSpinePosition** 는 **column count** 로 표현하였다.
 
 ![](https://hyuntaeeom-personal.s3.ap-northeast-2.amazonaws.com/RIDI+mini-vewer/viewer-store-change-diagram.png)
 

--- a/components/viewer/ViewerNcx.tsx
+++ b/components/viewer/ViewerNcx.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import styled from 'styled-components';
@@ -10,7 +10,7 @@ import * as viewerActions from '../../reducers/viewer';
 import { ReducerStates } from '../../interfaces';
 import { EpubNcxItem, EpubNavPoint } from '../../interfaces/books';
 
-import { getPageCountBySpineId } from '../../lib/util';
+import { getSpineIndexById, getPageCountBySpineIndex } from '../../lib/util';
 
 const Container = styled.div`
   position: relative;
@@ -59,9 +59,10 @@ const ViewerNcx: React.FunctionComponent<Props> = ({ ncxItem }) => {
   const { viewerCountList } = useSelector((state: ReducerStates) => state.viewer);
 
   const setPageCountBySpineId = useCallback((selectedSpineId) => {
-    const pageCountBySpineId = getPageCountBySpineId(viewerCountList, selectedSpineId);
-    if (pageCountBySpineId > -1) {
-      dispatch(viewerActions.setViewerPageCount(pageCountBySpineId));
+    const spineIndex = getSpineIndexById(viewerCountList, selectedSpineId);
+    if (spineIndex > -1) {
+      const pageCount = getPageCountBySpineIndex(viewerCountList, spineIndex);
+      dispatch(viewerActions.setViewerPageCount(pageCount));
     }
   }, [viewerCountList]);
 

--- a/components/viewer/ViewerPages.tsx
+++ b/components/viewer/ViewerPages.tsx
@@ -21,12 +21,15 @@ import {
   VIEWER_PAGE_GAP,
 } from '../../constants/viewer';
 
-import { getPageCountBySpineId, getMaxPageOffset } from '../../lib/util';
+import {
+  getPageCountBySpineIndex,
+  getMaxSpinePosition,
+  getSpineIndexByHref,
+} from '../../lib/util';
 
 import {
   usePageWithWithRatio,
-  usePagesOffset,
-  useViewerSpineId,
+  useSpineIndex,
   useSetBookCount,
 } from '../../hooks';
 
@@ -51,8 +54,8 @@ const ViewerPages: React.FunctionComponent<Props> = ({
 
   const {
     viewerCountList, viewerPageCount,
-    viewerLinkPageOffset,
-    viewerSpineId, viewerSpineOffset,
+    viewerLinkPosition,
+    viewerSpineIndex, viewerSpinePosition,
   }: ViewerState = useSelector((state: ReducerStates) => state.viewer);
   const {
     viewerWidth, widthRatio,
@@ -65,38 +68,35 @@ const ViewerPages: React.FunctionComponent<Props> = ({
     return countItems.length >= spineViewers.length;
   }, [privateStates, spineViewers]);
 
-  const nowSpineId = useViewerSpineId(viewerCountList, viewerPageCount);
-  const pagesOffset = usePagesOffset(viewerCountList, viewerPageCount);
+  const nowSpineIndex = useSpineIndex(viewerCountList, viewerPageCount);
   const widthWithRatio = usePageWithWithRatio(viewerWidth, widthRatio);
   const isSetCountList = useSetBookCount(viewerCountList, spines);
 
-  const setPageCountBySpineId = useCallback((spineId: string, offset?: number) => {
-    const pageCount = getPageCountBySpineId(viewerCountList, spineId);
-    if (pageCount > -1) {
-      dispatch(viewerActions.setViewerPageCount(pageCount + offset));
-    }
-  }, [viewerCountList]);
-
   useEffect(() => {
-    if (isSetCountList && viewerSpineId) {
-      const maxPageOffset = getMaxPageOffset(viewerCountList, viewerSpineId);
-      const pageOffset = viewerSpineOffset >= maxPageOffset ? maxPageOffset - 1 : viewerSpineOffset;
-      setPageCountBySpineId(viewerSpineId, pageOffset);
+    // Resize or Style 변경시 적용
+    if (isSetCountList && viewerSpineIndex > -1) {
+      const maxSpinePosition = getMaxSpinePosition(viewerCountList, viewerSpineIndex);
+      const pageCount = getPageCountBySpineIndex(viewerCountList, viewerSpineIndex);
+      const position = viewerSpinePosition >= maxSpinePosition
+        ? maxSpinePosition - 1
+        : viewerSpinePosition;
+      dispatch(viewerActions.setViewerPageCount(pageCount + position));
     }
   }, [isSetCountList]);
 
   useEffect(() => {
-    if (viewerLinkPageOffset) {
-      const { spineId, offset } = viewerLinkPageOffset;
-      setPageCountBySpineId(spineId, offset);
+    if (viewerLinkPosition) {
+      const { spineIndex: linkSpineIndex, position } = viewerLinkPosition;
+      const pageCount = getPageCountBySpineIndex(viewerCountList, linkSpineIndex);
+      dispatch(viewerActions.setViewerPageCount(pageCount + position));
     }
-  }, [viewerLinkPageOffset]);
+  }, [viewerLinkPosition]);
 
   useEffect(() => {
-    if (nowSpineId) {
-      dispatch(viewerActions.setViewerSpineId(nowSpineId));
+    if (nowSpineIndex > -1) {
+      dispatch(viewerActions.setViewerSpineIndex(nowSpineIndex));
     }
-  }, [nowSpineId]);
+  }, [nowSpineIndex]);
 
   /**
    * Calculate: Callback from single page, Set count in private store,
@@ -107,6 +107,7 @@ const ViewerPages: React.FunctionComponent<Props> = ({
     privateDispatch(addCount({
       index,
       count,
+      href: spine.href,
       spineId: spine.id,
     }));
   }, [spines]);
@@ -129,30 +130,23 @@ const ViewerPages: React.FunctionComponent<Props> = ({
    */
   useEffect(() => {
     const { current: containerCurrent } = containerRef;
-    containerCurrent.scrollLeft = pagesOffset * (widthWithRatio + VIEWER_PAGE_GAP);
-  }, [widthWithRatio, pagesOffset]);
-
-  const isSelectedSpineLink = useCallback(
-    (spineHref: string, selectedHref: string) => spineHref && selectedHref.includes(spineHref),
-    [],
-  );
+    containerCurrent.scrollLeft = nowSpineIndex * (widthWithRatio + VIEWER_PAGE_GAP);
+  }, [widthWithRatio, nowSpineIndex]);
 
   const clickLink = useCallback((spineHref: string, hashTag: string) => {
-    spines.some(({ href, id }) => {
-      if (isSelectedSpineLink(href, spineHref)) {
-        if (hashTag) {
-          dispatch(viewerActions.setViewerLink({
-            spineId: id,
-            tag: hashTag,
-          }));
-        } else {
-          setPageCountBySpineId(id, 0);
-        }
-        return true;
+    const spineIndex = getSpineIndexByHref(viewerCountList, spineHref);
+    if (spineIndex > -1) {
+      const pageCount = getPageCountBySpineIndex(viewerCountList, spineIndex);
+      if (hashTag) {
+        dispatch(viewerActions.setViewerLink({
+          spineIndex,
+          tag: hashTag,
+        }));
+      } else {
+        dispatch(viewerActions.setViewerPageCount(pageCount));
       }
-      return false;
-    });
-  }, [setPageCountBySpineId]);
+    }
+  }, [viewerCountList, spines]);
 
   return (
     <Container

--- a/components/viewer/ViewerPages.tsx
+++ b/components/viewer/ViewerPages.tsx
@@ -104,11 +104,12 @@ const ViewerPages: React.FunctionComponent<Props> = ({
    */
   const setCountCallback = useCallback((count: number, index: number) => {
     const spine = spines[index];
+    const { href, id } = spine;
     privateDispatch(addCount({
       index,
       count,
-      href: spine.href,
-      spineId: spine.id,
+      href,
+      spineId: id,
     }));
   }, [spines]);
 

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -3,29 +3,11 @@ import { useMemo } from 'react';
 import { EpubSpineItem } from '../interfaces/books';
 import { ViewerCount } from '../interfaces/viewer';
 
-export const useViewerSpineId = (
+export const useSpineIndex = (
   viewerCountList: ViewerCount[],
   viewerPageCount: number,
 ) => useMemo(() => {
-  let spineId = '';
-  let accurateCount = 0;
-  viewerCountList.some((viewerCount) => {
-    if (accurateCount > viewerPageCount) {
-      return true;
-    }
-    accurateCount += viewerCount.count;
-    spineId = viewerCount.spineId;
-    return false;
-  });
-
-  return spineId;
-}, [viewerPageCount]);
-
-export const usePagesOffset = (
-  viewerCountList: ViewerCount[],
-  viewerPageCount: number,
-) => useMemo(() => {
-  let spineIndex = 0;
+  let spineIndex = -1;
   let accurateCount = 0;
   viewerCountList.some((viewerCount) => {
     if (accurateCount + viewerCount.count > viewerPageCount) {
@@ -38,7 +20,7 @@ export const usePagesOffset = (
   return spineIndex;
 }, [viewerPageCount]);
 
-export const usePageOffset = (
+export const useSpinePosition = (
   viewerCountList: ViewerCount[],
   viewerPageCount: number,
   viewerIndex: number,

--- a/interfaces/viewer.ts
+++ b/interfaces/viewer.ts
@@ -2,10 +2,10 @@ export interface ViewerState {
   viewerCountList: ViewerCount[];
   viewerPageCount: number;
   viewerWholePageCount: number;
-  viewerSpineId: string;
-  viewerSpineOffset: number;
+  viewerSpineIndex: number;
+  viewerSpinePosition: number;
   viewerLink?: ViewerLink;
-  viewerLinkPageOffset?: ViewerLinkPageOffset;
+  viewerLinkPosition?: ViewerLinkPagePosition;
 }
 
 export interface ViewerSettingState extends ViewerStyle {
@@ -25,15 +25,16 @@ export interface ViewerCount {
   index: number;
   count: number;
   spineId: string;
+  href: string;
 }
 
 export interface ViewerLink {
-  spineId: string;
+  spineIndex: number;
   tag: string;
 }
 
-export interface ViewerLinkPageOffset extends ViewerLink {
-  offset: number;
+export interface ViewerLinkPagePosition extends ViewerLink {
+  position: number;
 }
 
 export interface SettingItem {

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -2,41 +2,62 @@ import { ViewerCount } from '../interfaces/viewer';
 
 export const isProduction = () => process.env.NODE_ENV === 'production';
 
-export const getPageCountBySpineId = (viewerCountList: ViewerCount[], spineId: string) => {
-  let pageCountIndex = -1;
-  let pageCount = -1;
+export const getSpineIndexById = (
+  viewerCountList: ViewerCount[],
+  id: string,
+) => {
+  let spineIndex = -1;
   viewerCountList.some((viewerCount, index) => {
-    if (viewerCount.spineId === spineId) {
-      pageCountIndex = index;
+    if (viewerCount.spineId === id) {
+      spineIndex = index;
       return true;
     }
     return false;
   });
 
-  if (pageCountIndex > -1) {
-    pageCount = 0;
-    viewerCountList.some((viewerCount, index) => {
-      if (index < pageCountIndex) {
-        pageCount += viewerCount.count;
-        return false;
-      }
-      return true;
-    });
-  }
-  return pageCount;
+  return spineIndex;
 };
 
-export const getMaxPageOffset = (viewerCountList: ViewerCount[], spineId: string) => {
-  let pageOffset = 0;
+export const getSpineIndexByHref = (
+  viewerCountList: ViewerCount[],
+  href: string,
+) => {
+  let spineIndex = -1;
   viewerCountList.some((viewerCount) => {
-    if (viewerCount.spineId === spineId) {
-      pageOffset = viewerCount.count;
+    if (href.includes(viewerCount.href)) {
+      spineIndex = viewerCount.index;
       return true;
     }
     return false;
   });
 
-  return pageOffset;
+  return spineIndex;
+};
+
+export const getPageCountBySpineIndex = (viewerCountList: ViewerCount[], index: number) => {
+  let accuratePageCount = 0;
+  viewerCountList.some((viewerCount) => {
+    if (viewerCount.index >= index) {
+      return true;
+    }
+    accuratePageCount += viewerCount.count;
+    return false;
+  });
+
+  return accuratePageCount;
+};
+
+export const getMaxSpinePosition = (viewerCountList: ViewerCount[], spineIndex: number) => {
+  let maxPagePosition = 0;
+  viewerCountList.some((viewerCount) => {
+    if (viewerCount.index === spineIndex) {
+      maxPagePosition = viewerCount.count;
+      return true;
+    }
+    return false;
+  });
+
+  return maxPagePosition;
 };
 
 

--- a/reducers/viewer.ts
+++ b/reducers/viewer.ts
@@ -1,13 +1,13 @@
 import { ReducerAction } from '../interfaces';
 import {
   ViewerState, ViewerCount,
-  ViewerLink, ViewerLinkPageOffset,
+  ViewerLink, ViewerLinkPagePosition,
 } from '../interfaces/viewer';
 
 export const initialState: ViewerState = {
   viewerCountList: [],
-  viewerSpineId: '',
-  viewerSpineOffset: 0,
+  viewerSpineIndex: -1,
+  viewerSpinePosition: 0,
   viewerPageCount: 0,
   viewerWholePageCount: 0,
 };
@@ -17,8 +17,8 @@ export const INIT_VIEWER_STATE = 'viewer/INIT_VIEWER_STATE';
 export const RESIZE_VIEWER_STATE = 'viewer/RESIZE_VIEWER_STATE';
 export const SET_VIEWER_COUNT_LIST = 'viewer/SET_VIEWER_COUNT_LIST';
 
-export const SET_VIEWER_SPINE_ID = 'viewer/SET_VIEWER_SPINE_ID';
-export const SET_VIEWER_SPINE_OFFSET = 'viewer/SET_VIEWER_SPINE_OFFSET';
+export const SET_VIEWER_SPINE_INDEX = 'viewer/SET_VIEWER_SPINE_INDEX';
+export const SET_VIEWER_SPINE_POSITION = 'viewer/SET_VIEWER_SPINE_POSITION';
 
 export const SET_VIEWER_PAGE_WHOLE_COUNT = 'viewer/SET_VIEWER_PAGE_WHOLE_COUNT';
 export const SET_VIEWER_PAGE_COUNT = 'viewer/SET_VIEWER_PAGE_COUNT';
@@ -26,7 +26,7 @@ export const SET_COUNT_UP_VIEWER_PAGE_COUNT = 'viewer/SET_COUNT_UP_VIEWER_PAGE_C
 export const SET_COUNT_DOWN_VIEWER_PAGE_COUNT = 'viewer/SET_COUNT_DOWN_VIEWER_PAGE_COUNT';
 
 export const SET_VIEWER_LINK = 'viewer/SET_VIEWER_LINK';
-export const SET_VIEWER_PAGE_OFFSET_INFO = 'viewer/SET_VIEWR_PAGE_OFFSET_INFO';
+export const SET_VIEWER_LINK_PAGE_POSITION_INFO = 'viewer/SET_VIEWER_LINK_PAGE_POSITION_INFO';
 
 // Action creators
 export const initViewerState = () => ({
@@ -44,17 +44,17 @@ export const setViewerCountList = (countList: ViewerCount[]) => ({
   },
 });
 
-export const setViewerSpineId = (spineId: string) => ({
-  type: SET_VIEWER_SPINE_ID,
+export const setViewerSpineIndex = (spineIndex: number) => ({
+  type: SET_VIEWER_SPINE_INDEX,
   payload: {
-    spineId,
+    spineIndex,
   },
 });
 
-export const setViewerSpineOffset = (spineOffset: number) => ({
-  type: SET_VIEWER_SPINE_OFFSET,
+export const setViewerSpinePosition = (spinePosition: number) => ({
+  type: SET_VIEWER_SPINE_POSITION,
   payload: {
-    spineOffset,
+    spinePosition,
   },
 });
 
@@ -87,8 +87,8 @@ export const setViewerLink = (params: ViewerLink) => ({
   },
 });
 
-export const setViewerLinkPageOffset = (params: ViewerLinkPageOffset) => ({
-  type: SET_VIEWER_PAGE_OFFSET_INFO,
+export const setViewerLinkPagePosition = (params: ViewerLinkPagePosition) => ({
+  type: SET_VIEWER_LINK_PAGE_POSITION_INFO,
   payload: {
     ...params,
   },
@@ -108,7 +108,7 @@ export default (state = initialState, action: ReducerAction): ViewerState => {
         viewerCountList: [],
         viewerWholePageCount: 0,
         viewerLink: null,
-        viewerLinkPageOffset: null,
+        viewerLinkPosition: null,
       };
     }
     case SET_VIEWER_COUNT_LIST: {
@@ -118,18 +118,18 @@ export default (state = initialState, action: ReducerAction): ViewerState => {
         viewerCountList: [...countList],
       };
     }
-    case SET_VIEWER_SPINE_ID: {
-      const { spineId } = payload;
+    case SET_VIEWER_SPINE_INDEX: {
+      const { spineIndex } = payload;
       return {
         ...state,
-        viewerSpineId: spineId,
+        viewerSpineIndex: spineIndex,
       };
     }
-    case SET_VIEWER_SPINE_OFFSET: {
-      const { spineOffset } = payload;
+    case SET_VIEWER_SPINE_POSITION: {
+      const { spinePosition } = payload;
       return {
         ...state,
-        viewerSpineOffset: spineOffset,
+        viewerSpinePosition: spinePosition,
       };
     }
     case SET_VIEWER_PAGE_COUNT: {
@@ -159,23 +159,23 @@ export default (state = initialState, action: ReducerAction): ViewerState => {
       };
     }
     case SET_VIEWER_LINK: {
-      const { spineId, tag } = payload;
+      const { spineIndex, tag } = payload;
       return {
         ...state,
         viewerLink: {
-          spineId,
+          spineIndex,
           tag,
         },
       };
     }
-    case SET_VIEWER_PAGE_OFFSET_INFO: {
-      const { spineId, offset, tag } = payload;
+    case SET_VIEWER_LINK_PAGE_POSITION_INFO: {
+      const { spineIndex, position, tag } = payload;
       return {
         ...state,
-        viewerLinkPageOffset: {
-          spineId,
+        viewerLinkPosition: {
+          spineIndex,
           tag,
-          offset,
+          position,
         },
       };
     }


### PR DESCRIPTION
기존 spine id 로 페이지를 찾던것을 모두 spine index  로 수정함
이유는 노션에서 spine_index, position 이라는 개념을 사용하고 있어서 같이 적용시켜봄